### PR TITLE
Deploy to Prod

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,22 @@
-:80 {
+{
+    auto_https off
+}
+
+:443 {
     # Route MQTT WebSocket traffic
     handle_path /mqtt* {
-        uri strip_prefix
+        reverse_proxy mosquitto:9001
+    }
+
+    # Route everything else to the Webpage
+    handle {
+        # This will point to website
+
+        respond "Web interface coming soon!" 200
+    }
+} {
+    # Route MQTT WebSocket traffic
+    handle_path /mqtt* {
         reverse_proxy mosquitto:9001
     }
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -14,16 +14,4 @@
 
         respond "Web interface coming soon!" 200
     }
-} {
-    # Route MQTT WebSocket traffic
-    handle_path /mqtt* {
-        reverse_proxy mosquitto:9001
-    }
-
-    # Route everything else to the Webpage
-    handle {
-        # This will point to website
-        
-        respond "Web interface coming soon!" 200
-    }
 }

--- a/README.md
+++ b/README.md
@@ -17,4 +17,8 @@ MQTT is our chosen protocol for managing the connection between the cars and the
 The Next.js instance that contains the Pits Display. This will most likely be the most resource-intensive and unpredictable portion of the deployment, as we will expect to have the general public to be able to connect to this endpoint and view the website.
 
 ### Usage
-To deploy this server, clone this repository and follow the instructions in Secrets Onboarding. Once onboarding is complete, run `./scripts/run-with-secrets.sh` to start the container and `docker compose down` to shut down the container (scripts use jq and yq, so ensure the machine has these installed).
++ To deploy this server, clone this repository and follow the instructions in Secrets Onboarding. 
++ Once onboarding is complete, run `./scripts/run-with-secrets.sh` to start the container and generate secrets and `docker compose down` to shut down the container. 
++ Subsequent docker container set ups can just be launched running `docker compose up -d` unless refreshing the passwd file with new users is desired.
+
+*Note: Scripts use jq and yq, so ensure the machine has these installed. Also, ensure that scripts/run-with-secrets.sh and mosquitto/entrypoint.sh are executable.*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,10 +22,12 @@ services:
     container_name: caddy
     restart: unless-stopped
     ports:
-      - "8080:80"
-      # - "8443:443"
+    #  - "8080:80"
+      - "443:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
+      - /etc/ssl/certs:/etc/ssl/certs:ro
+      - /etc/ssl/private:/etc/ssl/private:ro
     networks:
       - mqtt-net
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,8 +26,6 @@ services:
       - "443:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - /etc/ssl/certs:/etc/ssl/certs:ro
-      - /etc/ssl/private:/etc/ssl/private:ro
     networks:
       - mqtt-net
 

--- a/mosquitto/config/acl
+++ b/mosquitto/config/acl
@@ -3,13 +3,13 @@
 
 user karch
 # + matches a data topic and a config topic
-topic readwrite cars/car_a/+
-topic readwrite pit/chat/car_a
+topic readwrite cars/karch/+
+topic readwrite pit/chat/karch
 
 user sting
 # + matches a data topic and a config topic
-topic readwrite cars/car_b/+
-topic readwrite pit/chat/car_b
+topic readwrite cars/sting/+
+topic readwrite pit/chat/sting
 
 #pit crew publishes config and chat messages to any car
 #pit crew subscribes to any car's topics


### PR DESCRIPTION
+ Uses port 443 for encrypted https
+ Both supermileage.cedarville.edu and supermileage.cedarville.edu/mqtt can be reached
+ Functionality (such as acl rule enforcement for publishers and subscribers from another machine and connections made to the website and mqtt broker from another machine) was re-tested 

Closes #3