### PR TITLE
combined the config topics

### DIFF
--- a/mosquitto/config/acl
+++ b/mosquitto/config/acl
@@ -11,13 +11,15 @@ pattern read cars/+/data
 # --------------------
 user karch
 # + matches a data topic and a config topic
-topic readwrite cars/karch/+
+topic readwrite cars/karch/data
 topic readwrite pit/chat/karch
+topic readwrite cars/config
 
 user sting
 # + matches a data topic and a config topic
-topic readwrite cars/sting/+
+topic readwrite cars/sting/data
 topic readwrite pit/chat/sting
+topic readwrite cars/config
 
 #pit crew publishes config and chat messages to any car
 #pit crew subscribes to any car's topics
@@ -25,5 +27,5 @@ topic readwrite pit/chat/sting
 user pits_crew
 # + matches any car: car_a or car_b
 topic readwrite cars/+/data
-topic readwrite cars/+/config
+topic readwrite cars/config
 topic readwrite pit/chat/+


### PR DESCRIPTION
This is for this issue: https://github.com/HEEV/supermileage-display-web-pits/issues/8
cars/+/config now becomes a single cars/config topic to be consistent with the config schema having all car config data